### PR TITLE
Fix HTML documentation directory

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,12 +45,6 @@ jobs:
           git clone https://github.com/apple/swift-docc-render-artifact.git
           export DOCC_HTML_DIR="/Users/runner/work/verify-sdk-ios/swift-docc/swift-docc-render-artifact/dist"
 
-          cp -a ../Sources/adaptive/adaptive.docc/. ../.build/iOS-SDK.docc/ || true
-          cp -a ../Sources/authentication/authentication.docc/. ../.build/iOS-SDK.docc/ || true
-          cp -a ../Sources/core/core.docc/. ../.build/iOS-SDK.docc/ || true
-          cp -a ../Sources/fido2/fido2.docc/. ../.build/iOS-SDK.docc/ || true
-          cp -a ../Sources/mfa/mfa.docc/. ../.build/iOS-SDK.docc/ || true
-
           swift run docc convert ../.build/iOS-SDK.docc \
             --fallback-display-name iOS-SDK \
             --fallback-bundle-identifier com.ibm.iOS-SDK \
@@ -63,7 +57,7 @@ jobs:
         run: |
           git clone https://github.com/ibm-security-verify/ibm-security-verify.github.io.git
           cd ibm-security-verify.github.io
-          git checkout ios-documentation
+          git checkout master
           cd ..
           rm -r ibm-security-verify.github.io/ios/*
           mkdir -p ibm-security-verify.github.io/ios/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
           mkdir ../.build/iOS-SDK.docc
 
           git clone https://github.com/apple/swift-docc-render-artifact.git
-          export DOCC_HTML_DIR="/Users/runner/work/verify-sdk-ios/swift-docc/swift-docc-render-artifact/dist"
+          export DOCC_HTML_DIR="/Users/runner/work/verify-sdk-ios/verify-sdk-ios/swift-docc/swift-docc-render-artifact/dist"
 
           swift run docc convert ../.build/iOS-SDK.docc \
             --fallback-display-name iOS-SDK \


### PR DESCRIPTION
Correct internal workspace path uses the repo name twice, compared to once as in the original code. No idea why this works on personal repo.