### PR TITLE
Allow registration to servers with self signed Certificates

### DIFF
--- a/Sources/mfa/OnPremiseRegistrationProvider.swift
+++ b/Sources/mfa/OnPremiseRegistrationProvider.swift
@@ -100,8 +100,8 @@ public class OnPremiseRegistrationProvider: MFARegistrationDescriptor {
         
         // Perfom the request.
         self.metadata = try await self.urlSession.dataTask(for: resource)
-            
-        let oauthProvider = OAuthProvider(clientId: self.initializationInfo.clientId, additionalParameters: parameters)
+        
+        let oauthProvider = OAuthProvider(clientId: self.initializationInfo.clientId, ignoreSSLCertificate: self.initializationInfo.ignoreSSLCertificate, additionalParameters: parameters)
         self.token = try await oauthProvider.authorize(issuer: metadata.registrationUri, authorizationCode: self.initializationInfo.code, scope: ["mmfaAuthn"])
         
         // Check for the authenticator_id from the token additionalData.

--- a/Sources/mfa/OnPremiseRegistrationProvider.swift
+++ b/Sources/mfa/OnPremiseRegistrationProvider.swift
@@ -197,7 +197,7 @@ public class OnPremiseRegistrationProvider: MFARegistrationDescriptor {
                     "value":[{
                         "enabled":true,
                         "keyHandle":"\(keyHandle)",
-                        "algorithm":""\(self.currentFactor.algorithm)",
+                        "algorithm":"\(self.currentFactor.algorithm)",
                         "publicKey":"\(publicKey)"
                     }]
                 }]


### PR DESCRIPTION
Even though Authentication works with self signed certificates when option ignoreSsl=true is set, registration does not.
This was needed for my developing stage, so I made a Version which supports it.

It also fixes an error in json format of factor enrollment.